### PR TITLE
update the getResultsFromTarget function

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,7 @@
 #   go-tests = true
 #   unused-packages = true
 
+
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.0.0"
@@ -39,6 +40,10 @@
 [[constraint]]
   branch = "master"
   name = "github.com/republicprotocol/go-atom"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/republicprotocol/go-do"
 
 [[constraint]]
   branch = "master"

--- a/xing.go
+++ b/xing.go
@@ -108,57 +108,34 @@ func NotificationsFromTarget(target identity.MultiAddress, traderAddress identit
 }
 
 // GetResultsFromTarget using a new grpc.ClientConn to make a
-// GetResultsFromTarget RPC to a target identity.MultiAddress. This function
-// returns two channels. The first should be used to read compute.Results until
-// it is closed. The second should be closed by the caller when they no longer
-// want to receive compute.Results. After closing the quit channel, the caller
-// should read one last compute.Results from the first channel to guarantee
-// that no memory is leaked.
-func GetResultsFromTarget(target identity.MultiAddress, traderAddress identity.MultiAddress, timeout time.Duration) (chan do.Option, chan struct{}) {
-	ret := make(chan do.Option, 1)
-	quit := make(chan struct{}, 1)
+// GetResultsFromTarget RPC to a target identity.MultiAddress.
+func GetResultsFromTarget(target identity.MultiAddress, traderAddress identity.MultiAddress, timeout time.Duration) ([]*compute.Result, error) {
+	results := make([]*compute.Result, 0)
+	conn, err := Dial(target, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
 
-	go func() {
-		defer close(ret)
-		conn, err := Dial(target, timeout)
+	client := NewXingNodeClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	stream, err := client.GetResults(ctx, SerializeMultiAddress(traderAddress), grpc.FailFast(false))
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		result, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
-			ret <- do.Err(err)
-			return
+			return nil, err
 		}
-		defer conn.Close()
+		results = append(results, DeserializeResult(result))
+	}
 
-		client := NewXingNodeClient(conn)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-
-		stream, err := client.GetResults(ctx, SerializeMultiAddress(traderAddress), grpc.FailFast(false))
-		if err != nil {
-			ret <- do.Err(err)
-			return
-		}
-
-		for {
-			// Check if the quit channel is closed, without blocking.
-			select {
-			case _, ok := <-quit:
-				if !ok {
-					return
-				}
-			default:
-				// Do nothing.
-			}
-
-			result, err := stream.Recv()
-			if err == io.EOF {
-				return
-			}
-			if err != nil {
-				ret <- do.Err(err)
-				continue
-			}
-			ret <- do.Ok(DeserializeResult(result))
-		}
-	}()
-
-	return ret, quit
+	return results, nil
 }

--- a/xing_test.go
+++ b/xing_test.go
@@ -39,7 +39,7 @@ func (s *mockServer) Notifications(multiAddress *rpc.MultiAddress, stream rpc.Xi
 	return nil
 }
 
-func (s *mockServer) GetResults(multiAddress *rpc.MultiAddress,stream rpc.XingNode_GetResultsServer)  error {
+func (s *mockServer) GetResults(multiAddress *rpc.MultiAddress, stream rpc.XingNode_GetResultsServer) error {
 	stream.Send(rpc.SerializeResult(result))
 	return nil
 }
@@ -179,14 +179,14 @@ var _ = Describe("Xing Overlay Network", func() {
 			}(server)
 			defer server.Stop()
 
-			results, err  := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
+			results, err := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(len(results)).Should(BeNumerically(">" , 0))
+			Ω(len(results)).Should(BeNumerically(">", 0))
 			Ω(results[0]).Should(Equal(result))
 		})
 
 		It("should return an error when dialing an offline server", func() {
-			_, err  := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
+			_, err := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
 			Ω(err).Should(HaveOccurred())
 		})
 	})

--- a/xing_test.go
+++ b/xing_test.go
@@ -179,15 +179,15 @@ var _ = Describe("Xing Overlay Network", func() {
 			}(server)
 			defer server.Stop()
 
-			resultChan, _ := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
-			res := <- resultChan
-			Ω(res.Ok.(*compute.Result)).Should(Equal(result))
+			results, err  := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(len(results)).Should(BeNumerically(">" , 0))
+			Ω(results[0]).Should(Equal(result))
 		})
 
 		It("should return an error when dialing an offline server", func() {
-			resultChan, _ := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
-			res := <-resultChan
-			Ω(res.Err).ShouldNot(BeNil())
+			_, err  := rpc.GetResultsFromTarget(rpcServer.MultiAddress, rpcClient.MultiAddress, defaultTimeout)
+			Ω(err).Should(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
getResultsFromTarget now will return the results directly instead of two channels
